### PR TITLE
Populate ignoreLayout property for ChildInfo inside RefreshChildCache method

### DIFF
--- a/Runtime/Scripts/Layout.cs
+++ b/Runtime/Scripts/Layout.cs
@@ -805,6 +805,7 @@ namespace Poke.UI
                         index = i,
                         size = rt.rect.size,
                         enabled = rt.gameObject.activeInHierarchy,
+                        ignoreLayout = li.IgnoreLayout,
                     }
                 );
             }


### PR DESCRIPTION
When child cache is first built inside Layout.cs, RefreshChildCache method doesn't populate ignoreLayout field for ChildInfo. It leads to situations where items ignoring the layout actually receive layout updates on the first frame. 

Fix: populate ignoreLayout field from the very beginning to avoid unnecessary changes applied to elements that don't need it