### PR TITLE
Fix MissingReferenceException during list refresh

### DIFF
--- a/Runtime/Scripts/Layout.cs
+++ b/Runtime/Scripts/Layout.cs
@@ -386,7 +386,7 @@ namespace Poke.UI
         }
         
         private bool CheckIgnoreElem(ChildInfo ci) {
-            return !ci.enabled || ci.ignoreLayout;
+            return ci.rect == null || !ci.enabled || ci.ignoreLayout;
         }
 
         private void SetAnchorX(RectTransform rt, float x) {
@@ -1039,7 +1039,8 @@ namespace Poke.UI
             
             for(int i = 0; i < childCount; i++) {
                 RectTransform rt = transform.GetChild(i).GetComponent<RectTransform>();
-                
+                if (rt == null) continue;
+
                 Log($"Adding child \"{rt.name}\" - size: {rt.rect.size}");
                 
                 LayoutItem li = rt.GetComponent<LayoutItem>();


### PR DESCRIPTION
- Added null check for RectTransform in CheckIgnoreElem to handle destroyed children.
- Added null check in RefreshChildCache to skip children without RectTransform or those that have been destroyed.