### PR TITLE
Fixed missing dependency on `com.unity.ugui` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "displayName": "uLayout",
   "version": "1.6.3",
   "description": "A simple UI layout library for uGUI.",
-  "dependencies": {},
+  "dependencies": {
+    "com.unity.ugui": "0.0.1"
+  },
   "homepage": "https://github.com/pokeblokdude/uLayout",
   "bugs": {
     "url": "https://github.com/pokeblokdude/uLayout/issues"
@@ -13,7 +15,9 @@
     "url": "git@github.com:pokeblokdude/uLayout.git"
   },
   "license": "MIT",
-  "author": "pokeblokdude",
+  "author": {
+    "name": "pokeblokdude"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This will fix when importing the package into a project that doesn't have the com.unity.ugui package already installed.