### PR TITLE
fix(layout): stop ignored children dirtying the canvas every frame

### DIFF
--- a/Runtime/Scripts/Layout.cs
+++ b/Runtime/Scripts/Layout.cs
@@ -218,7 +218,7 @@ namespace Poke.UI
                     layoutChanged = true;
                 }
                 
-                if(c.rect.rect.size != c.size) {
+                if(!CheckIgnoreElem(c) && c.rect.rect.size != c.size) {
                     layoutChanged = true;
                 }
 


### PR DESCRIPTION
I noticed that cache for ignored stretched layout children is stale at start. In my case I think it's because values are cached before CanvasScaler resizes the canvas. Ignored children don't affect the layout, so they can be excluded from the size change check.